### PR TITLE
fix: windows batch file doesn't find Visual Studio

### DIFF
--- a/genvsmodel.py
+++ b/genvsmodel.py
@@ -1339,6 +1339,14 @@ def gen_makebat_win(arch: str, outpath: str):
           SET vsver=%%v
           SET vcvars=!p!
           GOTO Found
+        ) ELSE (
+          SET p="C:\\Program Files\\Microsoft Visual Studio\\%%v\\%%e\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+          IF EXIST !p! (
+            SET vsed=%%e
+            SET vsver=%%v
+            SET vcvars=!p!
+            GOTO Found
+          )
         )
       )
     )


### PR DESCRIPTION
Add case to check Program Files as well as Program Files (x86).